### PR TITLE
Fix concurrent access to resources w/ busy lock

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,7 +69,8 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 	sigolo.Info("Requested '%s'", fullUrl)
 
 	// Cache miss -> Load data from requested URL and add to cache
-	if !cache.has(fullUrl) {
+	if busy, ok := cache.has(fullUrl); !ok {
+		defer busy.Unlock()
 		response, err := client.Get(config.Target + fullUrl)
 		if err != nil {
 			handleError(err, w)


### PR DESCRIPTION
I introduce busy locks for each resources while it is being cached. If a
request for the same resource is made while it is being cached, the
client must wait before the resources has been cached completely.