### PR TITLE
Reduce response latency using streams

### DIFF
--- a/stream/buffer.go
+++ b/stream/buffer.go
@@ -1,0 +1,59 @@
+package stream
+
+import (
+	"io"
+	"sync"
+)
+
+// Buffer is an in-memory stream which supports one writer and multiple readers.
+// The stream is backed by a byte slice and concurrency is handled by an RWLock.
+type Buffer struct {
+	buf []byte
+	rw  *sync.RWMutex
+}
+
+// bufferReader represents a single reader of a Buffer. It essentialy is an
+// index into the Buffer which indicates the current position from read data
+// from. Multiple instances of bufferReader can read concurrently from the
+// underlying Buffer
+type bufferReader struct {
+	buffer *Buffer
+	i      int64
+}
+
+// NewBuffer returns an empty Buffer backed by a byte slice of initial length 0
+// and default capacity
+func NewBuffer() Source {
+	return &Buffer{
+		buf: make([]byte, 0),
+		rw:  new(sync.RWMutex),
+	}
+}
+
+// Open returns a new reader into Buffer. Open may be called multiple times to
+// retrieve multiple readers. All readers may read concurrently
+func (s *Buffer) Open() (io.Reader, error) {
+	return &bufferReader{
+		buffer: s,
+		i:      0,
+	}, nil
+}
+
+func (s *bufferReader) Read(b []byte) (n int, err error) {
+	s.buffer.rw.RLock()
+	defer s.buffer.rw.RUnlock()
+	if s.i >= int64(len(s.buffer.buf)) {
+		// No more data. Return EOF, Stream will wait for next write op
+		return 0, io.EOF
+	}
+	n = copy(b, s.buffer.buf[s.i:])
+	s.i += int64(n)
+	return
+}
+
+func (s *Buffer) Write(b []byte) (n int, err error) {
+	s.rw.Lock()
+	defer s.rw.Unlock()
+	s.buf = append(s.buf, b...)
+	return len(b), nil
+}

--- a/stream/buffer.go
+++ b/stream/buffer.go
@@ -32,28 +32,28 @@ func NewBuffer() Source {
 
 // Open returns a new reader into Buffer. Open may be called multiple times to
 // retrieve multiple readers. All readers may read concurrently
-func (s *Buffer) Open() (io.Reader, error) {
+func (b *Buffer) Open() (io.Reader, error) {
 	return &bufferReader{
-		buffer: s,
+		buffer: b,
 		i:      0,
 	}, nil
 }
 
-func (s *bufferReader) Read(b []byte) (n int, err error) {
-	s.buffer.rw.RLock()
-	defer s.buffer.rw.RUnlock()
-	if s.i >= int64(len(s.buffer.buf)) {
+func (b *bufferReader) Read(dst []byte) (n int, err error) {
+	b.buffer.rw.RLock()
+	defer b.buffer.rw.RUnlock()
+	if b.i >= int64(len(b.buffer.buf)) {
 		// No more data. Return EOF, Stream will wait for next write op
 		return 0, io.EOF
 	}
-	n = copy(b, s.buffer.buf[s.i:])
-	s.i += int64(n)
-	return
+	n = copy(dst, b.buffer.buf[b.i:])
+	b.i += int64(n)
+	return n, nil
 }
 
-func (s *Buffer) Write(b []byte) (n int, err error) {
-	s.rw.Lock()
-	defer s.rw.Unlock()
-	s.buf = append(s.buf, b...)
-	return len(b), nil
+func (b *Buffer) Write(src []byte) (n int, err error) {
+	b.rw.Lock()
+	defer b.rw.Unlock()
+	b.buf = append(b.buf, src...)
+	return len(src), nil
 }

--- a/stream/file.go
+++ b/stream/file.go
@@ -1,0 +1,28 @@
+package stream
+
+import (
+	"io"
+	"os"
+)
+
+// File is a source for streams which is backed by a file on the file system.
+// Concurrency and safety is provided by the file system, hence no need for
+// mutex/locks. The write method is provided for free by *os.File.
+type File struct {
+	*os.File
+}
+
+// NewFile creates a new file in path which is used as the source for a stream.
+// If the file cannot be created it panics.
+func NewFile(path string) Source {
+	file, err := os.Create(path)
+	if err != nil {
+		panic(err)
+	}
+	return &File{file}
+}
+
+// Open returns a new reader for the file by opening the file in read only mode.
+func (s File) Open() (io.Reader, error) {
+	return os.Open(s.Name())
+}

--- a/stream/file.go
+++ b/stream/file.go
@@ -23,6 +23,6 @@ func NewFile(path string) Source {
 }
 
 // Open returns a new reader for the file by opening the file in read only mode.
-func (s File) Open() (io.Reader, error) {
-	return os.Open(s.Name())
+func (f File) Open() (io.Reader, error) {
+	return os.Open(f.Name())
 }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -55,15 +55,15 @@ type streamReader struct {
 
 // NewReader returns a new reader for the stream. May be called multiple times
 // and each reader may read from the stream concurrently
-func (m *Stream) NewReader() (io.Reader, error) {
-	r, err := m.Open()
+func (s *Stream) NewReader() (io.Reader, error) {
+	r, err := s.Open()
 
 	if err != nil {
 		return nil, err
 	}
 
 	return &streamReader{
-		stream: m,
+		stream: s,
 		reader: r,
 	}, nil
 }
@@ -100,22 +100,22 @@ func (s *streamReader) Read(p []byte) (n int, err error) {
 	return
 }
 
-func (m *Stream) Write(data []byte) (int, error) {
-	defer m.cond.Broadcast()
-	return m.writer.Write(data)
+func (s *Stream) Write(data []byte) (int, error) {
+	defer s.cond.Broadcast()
+	return s.writer.Write(data)
 }
 
 // CloseWrite is called when the writer declares the end of the stream.
 // This is a clear indication for readers, that no more data will be written to
 // the stream. Following this call, readers will begin receiving EOF on calls to
 // read. Readers may still join the stream after the stream is closed
-func (m *Stream) CloseWrite() error {
-	m.cond.L.Lock()
-	defer m.cond.L.Unlock()
-	defer m.cond.Broadcast()
-	if m.closed {
+func (s *Stream) CloseWrite() error {
+	s.cond.L.Lock()
+	defer s.cond.L.Unlock()
+	defer s.cond.Broadcast()
+	if s.closed {
 		return errors.New("Multireader closed multiple times")
 	}
-	m.closed = true
+	s.closed = true
 	return nil
 }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -1,0 +1,121 @@
+// Package stream implements data streams which support one writer and multiple
+// concurrent readers. The Stream struct governs execution and suspension of
+// processed when data is available/unavailable. The Source struct handles
+// concurrent reads and writes to some data source. Streams are backed by such
+// a data Source implementation which is supplied as an in-memory and file
+// backed implementation
+package stream
+
+import (
+	"errors"
+	"io"
+	"sync"
+)
+
+// New returns a new stream. A stream will have one writer and multiple readers
+// which can read from the stream concurrently. The stream is backed by a source
+// which is typically an in-memory slice of bytes or a file on disk. When no
+// data is available for readers, readers will be suspended from execution. When
+// the writer writes new data to the stream all readers are notified. Only when
+// the writer explicitly declares the end of the stream (no more data to write),
+// readers will begin to receive EOF on following reads.
+func New(source Source) *Stream {
+	return &Stream{
+		Source: source,
+		writer: source,
+		cond:   sync.NewCond(new(sync.Mutex)),
+		closed: false,
+	}
+}
+
+// Source is the underlying data store for a stream. Multiple implementations
+// of sources may exist. Typical implementations are in-memory and file backed
+// sources. Implementation must as a bare minimum provide one writer, multiple
+// readers and concurrency.
+type Source interface {
+	io.Writer
+	Open() (io.Reader, error)
+}
+
+// Stream handles access to some concurrency safe data store (source) and
+// handles suspension of execution when no data is available through a
+// sync.Condition. When the stream is closed, the closed bool will be true
+type Stream struct {
+	Source
+	writer io.Writer
+	cond   *sync.Cond
+	closed bool
+}
+
+// streamReader is a single instance of a reader from a stream
+type streamReader struct {
+	stream *Stream
+	reader io.Reader
+}
+
+// NewReader returns a new reader for the stream. May be called multiple times
+// and each reader may read from the stream concurrently
+func (m *Stream) NewReader() (io.Reader, error) {
+	r, err := m.Open()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &streamReader{
+		stream: m,
+		reader: r,
+	}, nil
+}
+
+// Read reads data from the stream. If no data is currently available and the
+// stream has not closed, the read method will block until more data is
+// available. Only when the writer has declared no more data (closed = true)
+// will the reader receive EOF.
+func (s *streamReader) Read(p []byte) (n int, err error) {
+	s.stream.cond.L.Lock()
+	defer s.stream.cond.L.Unlock()
+	n, err = s.reader.Read(p)
+
+	// No errors, base case, return data
+	if err == nil {
+		return
+	}
+
+	// End of file reached
+	for err == io.EOF {
+		// If we are done writing, handle this as a normal case
+		if s.stream.closed {
+			return
+		}
+		// If partial data, return that data, mask the EOF since the writer may
+		// write additional data in the future
+		if n > 0 {
+			return n, nil
+		}
+		// Else, no data was read, wait until more data is available
+		s.stream.cond.Wait()
+		n, err = s.reader.Read(p)
+	}
+	return
+}
+
+func (m *Stream) Write(data []byte) (int, error) {
+	defer m.cond.Broadcast()
+	return m.writer.Write(data)
+}
+
+// CloseWrite is called when the writer declares the end of the stream.
+// This is a clear indication for readers, that no more data will be written to
+// the stream. Following this call, readers will begin receiving EOF on calls to
+// read. Readers may still join the stream after the stream is closed
+func (m *Stream) CloseWrite() error {
+	m.cond.L.Lock()
+	defer m.cond.L.Unlock()
+	defer m.cond.Broadcast()
+	if m.closed {
+		return errors.New("Multireader closed multiple times")
+	}
+	m.closed = true
+	return nil
+}

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -1,0 +1,50 @@
+package stream
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStream test that all readers of a stream will receive the same data as
+// written by the one writer. Each reader is running concurrently in a
+// goroutine. When all readers have verified their result, the test ends.
+// Checking that readers are done are performed by a sync.WaitGroup.
+func TestStream(t *testing.T) {
+	const numReaders = 16
+	const dataSize = 1024 * 1024 // 1 MiB
+
+	stream := New(NewBuffer())
+
+	wg := new(sync.WaitGroup)
+	wg.Add(numReaders)
+
+	r := rand.New(rand.NewSource(123))
+	buffer := new(bytes.Buffer)
+	io.CopyN(buffer, r, dataSize)
+	content := buffer.Bytes()
+
+	for i := 0; i < numReaders; i++ {
+		go func(i int) {
+			r, err := stream.NewReader()
+			defer wg.Done()
+			time.Sleep(time.Duration(i) * 50 * time.Millisecond)
+			require.Nil(t, err)
+			data, err := ioutil.ReadAll(r)
+			require.Nil(t, err)
+			assert.Equal(t, data, content)
+		}(i)
+	}
+
+	io.Copy(stream, bytes.NewBuffer(content))
+	err := stream.CloseWrite()
+	assert.Nil(t, err)
+	wg.Wait()
+}


### PR DESCRIPTION
This commit introduces streams which are used to reduce the latency
between a request for a resource and the start of transferring actual
data.

The issue stems from the fact that large resources need to be cached
completely until the first byte is written to the http response. I
propose streams to solve this issue such that the resource may be cached
and transmitted to the client simultaneously. Stream are concurrent and
thread safe and supports in-memory and file backed data stores.